### PR TITLE
[ISSUE-9] Introduce Logging Configuration Store

### DIFF
--- a/global.go
+++ b/global.go
@@ -35,7 +35,7 @@ func SetOverride(key string, value interface{}) {
 	v.SetOverride(key, value)
 }
 
-// Get retrievs the requested key from the global venom instance
+// Get retrieves the requested key from the global venom instance
 func Get(key string) interface{} {
 	return v.Get(key)
 }

--- a/helper_test.go
+++ b/helper_test.go
@@ -33,7 +33,7 @@ func assertEqualErrors(t *testing.T, expect, actual error) {
 	assert.Equal(t, expect, actual, msg)
 }
 
-// redirectStdout is explicitly for TestNewLogable test to pipe the contents
+// redirectStdout is explicitly for TestNewLoggable test to pipe the contents
 // sent to os.Stdout when implementing using the default logger.
 func redirectStdout(test struct{
 	tc  string

--- a/helper_test.go
+++ b/helper_test.go
@@ -6,6 +6,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestLogger has a no-op Print() method
+type TestLogger struct {}
+func (tl *TestLogger) Print(i ...interface{}) {}
+
 // kv is a test struct containing a (k)ey and a (v)alue
 type kv struct {
 	k string

--- a/helper_test.go
+++ b/helper_test.go
@@ -8,16 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestLogger has a no-op Print() method
+// TestLogger has no-op ReadLog WriteLog methods
 type TestLogger struct{}
 
-func (tl *TestLogger) Print(a ...interface{}) {}
-
-// TestLogWrapper has no-op ReadLog WriteLog methods
-type TestLogWrapper struct{}
-
-func (tl *TestLogWrapper) LogWrite(level ConfigLevel, key string, val interface{}) {}
-func (tl *TestLogWrapper) LogRead(key string, val interface{}, bl bool)            {}
+func (tl *TestLogger) LogWrite(level ConfigLevel, key string, val interface{}) {}
+func (tl *TestLogger) LogRead(key string, val interface{}, bl bool)            {}
 
 // kv is a test struct containing a (k)ey and a (v)alue
 type kv struct {

--- a/helper_test.go
+++ b/helper_test.go
@@ -9,8 +9,15 @@ import (
 )
 
 // TestLogger has a no-op Print() method
-type TestLogger struct {}
+type TestLogger struct{}
+
 func (tl *TestLogger) Print(a ...interface{}) {}
+
+// TestLogWrapper has no-op ReadLog WriteLog methods
+type TestLogWrapper struct{}
+
+func (tl *TestLogWrapper) LogWrite(level ConfigLevel, key string, val interface{}) {}
+func (tl *TestLogWrapper) LogRead(key string, val interface{}, bl bool)            {}
 
 // kv is a test struct containing a (k)ey and a (v)alue
 type kv struct {
@@ -35,7 +42,7 @@ func assertEqualErrors(t *testing.T, expect, actual error) {
 
 // redirectStdout is explicitly for TestNewLoggable test to pipe the contents
 // sent to os.Stdout when implementing using the default logger.
-func redirectStdout(test struct{
+func redirectStdout(test struct {
 	tc  string
 	f   func() *Venom
 	log bool

--- a/logger.go
+++ b/logger.go
@@ -2,6 +2,7 @@ package venom
 
 import (
 	"fmt"
+	"log"
 	"time"
 )
 
@@ -10,41 +11,35 @@ const (
 	LOG_NAME    = "[venom]"
 )
 
-// Logger is the interface which any logging mechanism must satisfy in order to
-// be used as the Logger mechanism wrapped by LogWrapper.
+// Logger is the interface a user must implement in order to be used by
+// the LogableConfigStore.
 type Logger interface {
-	Print(...interface{})
-}
-
-// LogWrapper is the wrapping interface by which a user must adhere in order to
-// be used by the LogableConfigStore.
-type LogWrapper interface {
 	LogWrite(level ConfigLevel, key string, val interface{})
 	LogRead(key string, val interface{}, bl bool)
 }
 
-// Entry is Venom's default LogWrapper and borrows the wording from logrus.
-type Entry struct {
-	Log Logger
+// StoreLogger is Venom's default Logger.
+type StoreLogger struct {
+	Log *log.Logger
 }
 
-// NewEntry returns a LogWrapper suitable for default use case.
-func NewEntry(l Logger) LogWrapper {
-	return &Entry{
+// NewStoreLogger returns a Logger suitable for default use case.
+func NewStoreLogger(l *log.Logger) Logger {
+	return &StoreLogger{
 		Log: l,
 	}
 }
 
 // LogWrite is the default logging behavior of a LoggableConfigStore on an
 // action to set a value in the ConfigStore.
-func (e *Entry) LogWrite(level ConfigLevel, key string, val interface{}) {
+func (sl *StoreLogger) LogWrite(level ConfigLevel, key string, val interface{}) {
 	logLine := fmt.Sprintf("%s%s: writing level=%v key=%s val=%s", time.Now().UTC().Format(TIME_FORMAT), LOG_NAME, level, key, val)
-	e.Log.Print(logLine)
+	sl.Log.Print(logLine)
 }
 
 // LogWrite is the default logging behavior of a LoggableConfigStore on an
 // action to read a value in the ConfigStore.
-func (e *Entry) LogRead(key string, val interface{}, bl bool) {
+func (sl *StoreLogger) LogRead(key string, val interface{}, bl bool) {
 	logLine := fmt.Sprintf("%s%s: reading key=%s val=%s exist=%v", time.Now().UTC().Format(TIME_FORMAT), LOG_NAME, key, val, bl)
-	e.Log.Print(logLine)
+	sl.Log.Print(logLine)
 }

--- a/logger.go
+++ b/logger.go
@@ -15,7 +15,6 @@ const (
 // in order to be used as the logging mechanism for a LoggableConfigStore.
 type LoggingInterface interface {
     Print(...interface{})
-    // Printf(string, ...interface{})
 }
 
 // DefaultLogger is the struct associated with the LoggableConfigStore. It has

--- a/logger.go
+++ b/logger.go
@@ -7,22 +7,44 @@ import (
 
 const (
 	TIME_FORMAT = "2006-01-02T15:04:05.999Z"
-	LOG_NAME = "[venom]"
+	LOG_NAME    = "[venom]"
 )
 
-// Logging is the interface which any logging mechanism must satisfy
-// in order to be used as the logging mechanism for a LoggableConfigStore.
-type Logging interface {
+// Logger is the interface which any logging mechanism must satisfy in order to
+// be used as the Logger mechanism wrapped by LogWrapper.
+type Logger interface {
 	Print(...interface{})
 }
 
-// formatLogLine produces a default log line structure for the Logging interface
-// print function to use.
-func formatLogLine(a ...interface{}) string {
-	logLine := fmt.Sprintf("%s%s:", time.Now().UTC().Format(TIME_FORMAT), LOG_NAME)
-	for _, v := range a {
-		logLine += fmt.Sprintf(" %v", v)
-	}
+// LogWrapper is the wrapping interface by which a user must adhere in order to
+// be used by the LogableConfigStore.
+type LogWrapper interface {
+	LogWrite(level ConfigLevel, key string, val interface{})
+	LogRead(key string, val interface{}, bl bool)
+}
 
-	return logLine
+// Entry is Venom's default LogWrapper and borrows the wording from logrus.
+type Entry struct {
+	Log Logger
+}
+
+// NewEntry returns a LogWrapper suitable for default use case.
+func NewEntry(l Logger) LogWrapper {
+	return &Entry{
+		Log: l,
+	}
+}
+
+// LogWrite is the default logging behavior of a LoggableConfigStore on an
+// action to set a value in the ConfigStore.
+func (e *Entry) LogWrite(level ConfigLevel, key string, val interface{}) {
+	logLine := fmt.Sprintf("%s%s: writing level=%v key=%s val=%s", time.Now().UTC().Format(TIME_FORMAT), LOG_NAME, level, key, val)
+	e.Log.Print(logLine)
+}
+
+// LogWrite is the default logging behavior of a LoggableConfigStore on an
+// action to read a value in the ConfigStore.
+func (e *Entry) LogRead(key string, val interface{}, bl bool) {
+	logLine := fmt.Sprintf("%s%s: reading key=%s val=%s exist=%v", time.Now().UTC().Format(TIME_FORMAT), LOG_NAME, key, val, bl)
+	e.Log.Print(logLine)
 }

--- a/logger.go
+++ b/logger.go
@@ -10,34 +10,34 @@ const (
 	LOG_NAME = "[venom]"
 )
 
-// LoggingInterface is the interface which any logging mechanism must satisfy
+// Logging is the interface which any logging mechanism must satisfy
 // in order to be used as the logging mechanism for a LoggableConfigStore.
-type LoggingInterface interface {
+type Logging interface {
 	Print(...interface{})
 }
 
 // DefaultLogger is the struct associated with the LoggableConfigStore. It has
 // three configurable fields which ultimately compose structured log lines.
 type DefaultLogger struct {
-	log    LoggingInterface
+	log    Logging
 	suffix string
 }
 
 // NewDefaultLogger returns a reference to an instance of a DefaultLogger
 // struct with defaults for all fields.
-func NewLogger(l LoggingInterface) *DefaultLogger {
-	return &DefaultLogger {
+func NewLogger(l Logging) DefaultLogger {
+	return DefaultLogger {
 		log:    l,
 		suffix: LOG_NAME,
 	}
 }
 
 // Write takes a slice of interfaces and prints them as a structured log line
-// using the DefaultLogger's log which is a LoggingInterface.
+// using the DefaultLogger's log which is a Logging.
 func (lg *DefaultLogger) Write(a ...interface{}) {
-	logLine := fmt.Sprintf("%s%s: ", time.Now().UTC().Format(TIME_FORMAT), lg.suffix)
+	logLine := fmt.Sprintf("%s%s:", time.Now().UTC().Format(TIME_FORMAT), lg.suffix)
 	for _, v := range a {
-		logLine += fmt.Sprintf(" %s", v)
+		logLine += fmt.Sprintf(" %v", v)
 	}
 
 	lg.log.Print(logLine)

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,64 @@
+package venom
+
+import (
+    "fmt"
+    "log"
+    "os"
+    "time"
+)
+
+const (
+    TIME_FORMAT = "2006-01-02T15:04:05.999Z"
+)
+
+// LoggingInterface is the interface which any logging mechanism must satisfy
+// in order to be used as the logging mechanism for a LoggableConfigStore.
+type LoggingInterface interface {
+    Print(...interface{})
+    // Printf(string, ...interface{})
+}
+
+// DefaultLogger is the struct associated with the LoggableConfigStore. It has
+// three configurable fields which ultimately compose structured log lines.
+type DefaultLogger struct {
+    log    LoggingInterface
+    Suffix string
+    Prefix string
+}
+
+// NewDefaultLogger returns a reference to an instance of a DefaultLogger
+// struct with defaults for all fields.
+func NewDefaultLogger() *DefaultLogger {
+    return &DefaultLogger {
+        log:    log.New(os.Stdout, "", 0),
+        Suffix: "venom",
+        Prefix: "INFO",
+    }
+}
+
+// Write takes a slice of interfaces and prints them as a structured log line
+// using the DefaultLogger's log which is a LoggingInterface.
+func (lg *DefaultLogger) Write(a ...interface{}) {
+    logLine := fmt.Sprintf("%s %s - %s: ", lg.Prefix, time.Now().UTC().Format(TIME_FORMAT), lg.Suffix)
+    for _, v := range a {
+        logLine += fmt.Sprintf(" %s", v)
+    }
+
+    lg.log.Print(logLine)
+}
+
+// SetLogger takes an parameter of type LoggingInterface and sets it as the log
+// field for a DefaultLogger.
+func (lg *DefaultLogger) SetLogger(logger LoggingInterface) {
+    lg.log = logger
+}
+
+// SetPrefix takes a string and sets the DefaultLogger's Prefix field.
+func (lg *DefaultLogger) SetPrefix(s string) {
+    lg.Prefix = s
+}
+
+// SetSuffix takes a string and sets the DefaultLogger's Suffix field.
+func (lg *DefaultLogger) SetSuffix(s string) {
+    lg.Suffix = s
+}

--- a/logger.go
+++ b/logger.go
@@ -16,29 +16,13 @@ type Logging interface {
 	Print(...interface{})
 }
 
-// DefaultLogger is the struct associated with the LoggableConfigStore. It has
-// three configurable fields which ultimately compose structured log lines.
-type DefaultLogger struct {
-	log    Logging
-	suffix string
-}
-
-// NewDefaultLogger returns a reference to an instance of a DefaultLogger
-// struct with defaults for all fields.
-func NewLogger(l Logging) DefaultLogger {
-	return DefaultLogger {
-		log:    l,
-		suffix: LOG_NAME,
-	}
-}
-
-// Write takes a slice of interfaces and prints them as a structured log line
-// using the DefaultLogger's log which is a Logging.
-func (lg *DefaultLogger) Write(a ...interface{}) {
-	logLine := fmt.Sprintf("%s%s:", time.Now().UTC().Format(TIME_FORMAT), lg.suffix)
+// formatLogLine produces a default log line structure for the Logging interface
+// print function to use.
+func formatLogLine(a ...interface{}) string {
+	logLine := fmt.Sprintf("%s%s:", time.Now().UTC().Format(TIME_FORMAT), LOG_NAME)
 	for _, v := range a {
 		logLine += fmt.Sprintf(" %v", v)
 	}
 
-	lg.log.Print(logLine)
+	return logLine
 }

--- a/logger.go
+++ b/logger.go
@@ -1,63 +1,44 @@
 package venom
 
 import (
-    "fmt"
-    "log"
-    "os"
-    "time"
+	"fmt"
+	"time"
 )
 
 const (
-    TIME_FORMAT = "2006-01-02T15:04:05.999Z"
+	TIME_FORMAT = "2006-01-02T15:04:05.999Z"
+	LOG_NAME = "[venom]"
 )
 
 // LoggingInterface is the interface which any logging mechanism must satisfy
 // in order to be used as the logging mechanism for a LoggableConfigStore.
 type LoggingInterface interface {
-    Print(...interface{})
+	Print(...interface{})
 }
 
 // DefaultLogger is the struct associated with the LoggableConfigStore. It has
 // three configurable fields which ultimately compose structured log lines.
 type DefaultLogger struct {
-    log    LoggingInterface
-    Suffix string
-    Prefix string
+	log    LoggingInterface
+	suffix string
 }
 
 // NewDefaultLogger returns a reference to an instance of a DefaultLogger
 // struct with defaults for all fields.
-func NewDefaultLogger() *DefaultLogger {
-    return &DefaultLogger {
-        log:    log.New(os.Stdout, "", 0),
-        Suffix: "venom",
-        Prefix: "INFO",
-    }
+func NewLogger(l LoggingInterface) *DefaultLogger {
+	return &DefaultLogger {
+		log:    l,
+		suffix: LOG_NAME,
+	}
 }
 
 // Write takes a slice of interfaces and prints them as a structured log line
 // using the DefaultLogger's log which is a LoggingInterface.
 func (lg *DefaultLogger) Write(a ...interface{}) {
-    logLine := fmt.Sprintf("%s %s - %s: ", lg.Prefix, time.Now().UTC().Format(TIME_FORMAT), lg.Suffix)
-    for _, v := range a {
-        logLine += fmt.Sprintf(" %s", v)
-    }
+	logLine := fmt.Sprintf("%s%s: ", time.Now().UTC().Format(TIME_FORMAT), lg.suffix)
+	for _, v := range a {
+		logLine += fmt.Sprintf(" %s", v)
+	}
 
-    lg.log.Print(logLine)
-}
-
-// SetLogger takes an parameter of type LoggingInterface and sets it as the log
-// field for a DefaultLogger.
-func (lg *DefaultLogger) SetLogger(logger LoggingInterface) {
-    lg.log = logger
-}
-
-// SetPrefix takes a string and sets the DefaultLogger's Prefix field.
-func (lg *DefaultLogger) SetPrefix(s string) {
-    lg.Prefix = s
-}
-
-// SetSuffix takes a string and sets the DefaultLogger's Suffix field.
-func (lg *DefaultLogger) SetSuffix(s string) {
-    lg.Suffix = s
+	lg.log.Print(logLine)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -2,8 +2,8 @@ package venom
 
 import (
 	"fmt"
-	"os"
 	"log"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,8 +11,8 @@ import (
 
 func TestNewLoggableWith(t *testing.T) {
 	testIO := []struct {
-		tc   string
-		lgr  Logging
+		tc  string
+		lgr Logger
 	}{
 		{
 			tc:  "should be able to set a no-op logging interface",
@@ -30,7 +30,8 @@ func TestNewLoggableWith(t *testing.T) {
 
 	for _, test := range testIO {
 		t.Run(test.tc, func(t *testing.T) {
-			l := NewLoggableWith(test.lgr)
+			lw := NewEntry(test.lgr)
+			l := NewLoggableWith(lw)
 			assert.IsType(t, l, &Venom{})
 		})
 	}
@@ -44,46 +45,46 @@ func TestNewLoggable(t *testing.T) {
 		kv  kv
 	}{
 		{
-			tc: "should be receive a default to stdout if Loggable",
-			f:  NewLoggable,
+			tc:  "should be receive a default to stdout if Loggable",
+			f:   NewLoggable,
 			log: true,
-			kv: kv{k: "foo", v: "bar"},
+			kv:  kv{k: "foo", v: "bar"},
 		},
 		{
-			tc: "should not log if new default store",
-			f:  New,
+			tc:  "should not log if new default store",
+			f:   New,
 			log: false,
-			kv: kv{k: "foo", v: "bar"},
+			kv:  kv{k: "foo", v: "bar"},
 		},
 		{
-			tc: "should not log if new safe store",
-			f: NewSafe,
+			tc:  "should not log if new safe store",
+			f:   NewSafe,
 			log: false,
-			kv: kv{k: "foo", v: "bar"},
+			kv:  kv{k: "foo", v: "bar"},
 		},
 		{
-			tc: "should log to stdout with a value type int",
-			f:  NewLoggable,
+			tc:  "should log to stdout with a value type int",
+			f:   NewLoggable,
 			log: true,
-			kv: kv{k: "foo", v: 100},
+			kv:  kv{k: "foo", v: 100},
 		},
 		{
-			tc: "should log to stdout with a value type float",
-			f:  NewLoggable,
+			tc:  "should log to stdout with a value type float",
+			f:   NewLoggable,
 			log: true,
-			kv: kv{k: "foo", v: 10.0},
+			kv:  kv{k: "foo", v: 10.0},
 		},
 		{
-			tc: "should log to stdout with a value type boolean true",
-			f:  NewLoggable,
+			tc:  "should log to stdout with a value type boolean true",
+			f:   NewLoggable,
 			log: true,
-			kv: kv{k: "foo", v: true},
+			kv:  kv{k: "foo", v: true},
 		},
 		{
-			tc: "should log to stdout with a value type boolean false",
-			f:  NewLoggable,
+			tc:  "should log to stdout with a value type boolean false",
+			f:   NewLoggable,
 			log: true,
-			kv: kv{k: "foo", v: false},
+			kv:  kv{k: "foo", v: false},
 		},
 	}
 
@@ -91,7 +92,7 @@ func TestNewLoggable(t *testing.T) {
 		t.Run(test.tc, func(t *testing.T) {
 			out := redirectStdout(test)
 			if test.log {
-				assert.Contains(t, out, fmt.Sprintf("[venom]: SET 0 %v %v", test.kv.k, test.kv.v))
+				assert.Contains(t, out, fmt.Sprintf("writing level=0 key=%s val=%s", test.kv.k, test.kv.v))
 			} else {
 				assert.Empty(t, out)
 			}

--- a/logger_test.go
+++ b/logger_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewLogableWith(t *testing.T) {
+func TestNewLoggableWith(t *testing.T) {
 	testIO := []struct {
 		tc   string
-		lgr  LoggingInterface
+		lgr  Logging
 	}{
 		{
 			tc:  "should be able to set a no-op logging interface",
@@ -30,13 +30,13 @@ func TestNewLogableWith(t *testing.T) {
 
 	for _, test := range testIO {
 		t.Run(test.tc, func(t *testing.T) {
-			l := NewLogableWith(test.lgr)
+			l := NewLoggableWith(test.lgr)
 			assert.IsType(t, l, &Venom{})
 		})
 	}
 }
 
-func TestNewLogable(t *testing.T) {
+func TestNewLoggable(t *testing.T) {
 	testIO := []struct {
 		tc  string
 		f   func() *Venom
@@ -44,8 +44,8 @@ func TestNewLogable(t *testing.T) {
 		kv  kv
 	}{
 		{
-			tc: "should be receive a default to stdout if logable",
-			f:  NewLogable,
+			tc: "should be receive a default to stdout if Loggable",
+			f:  NewLoggable,
 			log: true,
 			kv: kv{k: "foo", v: "bar"},
 		},
@@ -63,25 +63,25 @@ func TestNewLogable(t *testing.T) {
 		},
 		{
 			tc: "should log to stdout with a value type int",
-			f:  NewLogable,
+			f:  NewLoggable,
 			log: true,
 			kv: kv{k: "foo", v: 100},
 		},
 		{
 			tc: "should log to stdout with a value type float",
-			f:  NewLogable,
+			f:  NewLoggable,
 			log: true,
 			kv: kv{k: "foo", v: 10.0},
 		},
 		{
 			tc: "should log to stdout with a value type boolean true",
-			f:  NewLogable,
+			f:  NewLoggable,
 			log: true,
 			kv: kv{k: "foo", v: true},
 		},
 		{
 			tc: "should log to stdout with a value type boolean false",
-			f:  NewLogable,
+			f:  NewLoggable,
 			log: true,
 			kv: kv{k: "foo", v: false},
 		},
@@ -91,7 +91,7 @@ func TestNewLogable(t *testing.T) {
 		t.Run(test.tc, func(t *testing.T) {
 			out := redirectStdout(test)
 			if test.log {
-				assert.Contains(t, out, fmt.Sprintf("[venom]:  [%s %s]", test.kv.k, test.kv.v))
+				assert.Contains(t, out, fmt.Sprintf("[venom]: SET 0 %v %v", test.kv.k, test.kv.v))
 			} else {
 				assert.Empty(t, out)
 			}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,42 @@
+package venom
+
+import (
+    "os"
+    "log"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestSetLogger(t *testing.T) {
+    testIO := []struct {
+        tc   string
+        lgr  LoggingInterface
+        tipe interface{}
+    }{
+        {
+            tc:   "should be able to set a no-op logging interface",
+            lgr:  &TestLogger{},
+            tipe: &TestLogger{},
+        },
+        {
+            tc:   "should be able set to a new io.Writer (stderr)",
+            lgr:  log.New(os.Stderr, "", 0),
+            tipe: &log.Logger{},
+        },
+    }
+
+    for _, test := range testIO {
+        t.Run(test.tc, func(t *testing.T) {
+            l := NewLogable()
+            defaultLog := l.GetLogger().(*log.Logger)
+            assert.IsType(t, &log.Logger{}, defaultLog)
+            
+            l.SetLogger(test.lgr)
+            customLog := l.GetLogger()
+            assert.IsType(t, test.tipe, customLog)
+        })
+    }
+}
+
+

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,42 +1,100 @@
 package venom
 
 import (
-    "os"
-    "log"
-    "testing"
+	"fmt"
+	"os"
+	"log"
+	"testing"
 
-    "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestSetLogger(t *testing.T) {
-    testIO := []struct {
-        tc   string
-        lgr  LoggingInterface
-        tipe interface{}
-    }{
-        {
-            tc:   "should be able to set a no-op logging interface",
-            lgr:  &TestLogger{},
-            tipe: &TestLogger{},
-        },
-        {
-            tc:   "should be able set to a new io.Writer (stderr)",
-            lgr:  log.New(os.Stderr, "", 0),
-            tipe: &log.Logger{},
-        },
-    }
+func TestNewLogableWith(t *testing.T) {
+	testIO := []struct {
+		tc   string
+		lgr  LoggingInterface
+	}{
+		{
+			tc:  "should be able to set a no-op logging interface",
+			lgr: &TestLogger{},
+		},
+		{
+			tc:  "should be able set to an io.Writer (stderr)",
+			lgr: log.New(os.Stderr, "", 0),
+		},
+		{
+			tc:  "should be able set to an io.Writer (stdout)",
+			lgr: log.New(os.Stdout, "", 0),
+		},
+	}
 
-    for _, test := range testIO {
-        t.Run(test.tc, func(t *testing.T) {
-            l := NewLogable()
-            defaultLog := l.GetLogger().(*log.Logger)
-            assert.IsType(t, &log.Logger{}, defaultLog)
-            
-            l.SetLogger(test.lgr)
-            customLog := l.GetLogger()
-            assert.IsType(t, test.tipe, customLog)
-        })
-    }
+	for _, test := range testIO {
+		t.Run(test.tc, func(t *testing.T) {
+			l := NewLogableWith(test.lgr)
+			assert.IsType(t, l, &Venom{})
+		})
+	}
 }
 
+func TestNewLogable(t *testing.T) {
+	testIO := []struct {
+		tc  string
+		f   func() *Venom
+		log bool
+		kv  kv
+	}{
+		{
+			tc: "should be receive a default to stdout if logable",
+			f:  NewLogable,
+			log: true,
+			kv: kv{k: "foo", v: "bar"},
+		},
+		{
+			tc: "should not log if new default store",
+			f:  New,
+			log: false,
+			kv: kv{k: "foo", v: "bar"},
+		},
+		{
+			tc: "should not log if new safe store",
+			f: NewSafe,
+			log: false,
+			kv: kv{k: "foo", v: "bar"},
+		},
+		{
+			tc: "should log to stdout with a value type int",
+			f:  NewLogable,
+			log: true,
+			kv: kv{k: "foo", v: 100},
+		},
+		{
+			tc: "should log to stdout with a value type float",
+			f:  NewLogable,
+			log: true,
+			kv: kv{k: "foo", v: 10.0},
+		},
+		{
+			tc: "should log to stdout with a value type boolean true",
+			f:  NewLogable,
+			log: true,
+			kv: kv{k: "foo", v: true},
+		},
+		{
+			tc: "should log to stdout with a value type boolean false",
+			f:  NewLogable,
+			log: true,
+			kv: kv{k: "foo", v: false},
+		},
+	}
 
+	for _, test := range testIO {
+		t.Run(test.tc, func(t *testing.T) {
+			out := redirectStdout(test)
+			if test.log {
+				assert.Contains(t, out, fmt.Sprintf("[venom]:  [%s %s]", test.kv.k, test.kv.v))
+			} else {
+				assert.Empty(t, out)
+			}
+		})
+	}
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -12,12 +12,8 @@ import (
 func TestNewLoggableWith(t *testing.T) {
 	testIO := []struct {
 		tc  string
-		lgr Logger
+		lgr *log.Logger
 	}{
-		{
-			tc:  "should be able to set a no-op logging interface",
-			lgr: &TestLogger{},
-		},
 		{
 			tc:  "should be able set to an io.Writer (stderr)",
 			lgr: log.New(os.Stderr, "", 0),
@@ -30,7 +26,7 @@ func TestNewLoggableWith(t *testing.T) {
 
 	for _, test := range testIO {
 		t.Run(test.tc, func(t *testing.T) {
-			lw := NewEntry(test.lgr)
+			lw := NewStoreLogger(test.lgr)
 			l := NewLoggableWith(lw)
 			assert.IsType(t, l, &Venom{})
 		})

--- a/store.go
+++ b/store.go
@@ -164,23 +164,23 @@ func (s *DefaultConfigStore) Debug() string {
 }
 
 // SetLogger is not implemented for a DefaultConfigStore and is present
-// only to satisfy the interface.
+// only to satisfy the ConfigStore interface.
 func (s *DefaultConfigStore) SetLogger(lg LoggingInterface) {
 }
 
 // GetLogger is not implemented for a DefaultConfigStore and is present
-// only to satisfy the interface.
+// only to satisfy the ConfigStore interface.
 func (s *DefaultConfigStore) GetLogger() LoggingInterface {
 	return nil
 }
 
 // SetPrefix is not implemented for a DefaultConfigStore and is present
-// only to satisfy the interface.
+// only to satisfy the ConfigStore interface.
 func (s *DefaultConfigStore) SetPrefix(str string) {
 }
 
 // SetSuffix is not implemented for a DefaultConfigStore and is present
-// only to satisfy the interface.
+// only to satisfy the ConfigStore interface.
 func (s *DefaultConfigStore) SetSuffix(str string) {
 }
 
@@ -267,23 +267,23 @@ func (s *SafeConfigStore) Size() int {
 }
 
 // SetLogger is not implemented for a DefaultConfigStore and is present
-// only to satisfy the interface.
+// only to satisfy the ConfigStore interface.
 func (s *SafeConfigStore) SetLogger(lg LoggingInterface) {
 }
 
 // GetLogger is not implemented for a DefaultConfigStore and is present
-// only to satisfy the interface.
+// only to satisfy the ConfigStore interface.
 func (s *SafeConfigStore) GetLogger() LoggingInterface {
 	return nil
 }
 
 // SetPrefix is not implemented for a DefaultConfigStore and is present
-// only to satisfy the interface.
+// only to satisfy the ConfigStore interface.
 func (s *SafeConfigStore) SetPrefix(str string) {
 }
 
 // SetSuffix is not implemented for a DefaultConfigStore and is present
-// only to satisfy the interface.
+// only to satisfy the ConfigStore interface.
 func (s *SafeConfigStore) SetSuffix(str string) {
 }
 

--- a/store.go
+++ b/store.go
@@ -3,6 +3,8 @@ package venom
 import (
 	"container/heap"
 	"encoding/json"
+	"log"
+	"os"
 	"strings"
 	"sync"
 )
@@ -19,10 +21,6 @@ type ConfigStore interface {
 	Clear()
 	Debug() string
 	Size() int
-	SetLogger(LoggingInterface)
-	GetLogger() LoggingInterface
-	SetPrefix(string)
-	SetSuffix(string)
 }
 
 // DefaultConfigStore is the minimum implementation of a ConfigStore. It is
@@ -42,6 +40,9 @@ type DefaultConfigStore struct {
 
 	// aliases contains the collection of any aliased config values
 	aliases map[string]string
+
+	// if a store which is logable is desired
+	log *DefaultLogger
 }
 
 // NewDefaultConfigStore returns a newly allocated DefaultConfigStore.
@@ -51,6 +52,17 @@ func NewDefaultConfigStore() *DefaultConfigStore {
 		usedLevels: NewConfigLevelHeap(),
 		resolvers:  make(map[ConfigLevel]Resolver),
 		aliases:    make(map[string]string),
+	}
+}
+
+// unexported function for generating a DefaultConfigStore with a log.
+func newLogableConfigStoreWith(l LoggingInterface) *DefaultConfigStore {
+	return &DefaultConfigStore{
+		config:     make(ConfigLevelMap),
+		usedLevels: NewConfigLevelHeap(),
+		resolvers:  make(map[ConfigLevel]Resolver),
+		aliases:    make(map[string]string),
+		log: NewLogger(l),
 	}
 }
 
@@ -79,12 +91,15 @@ func (s *DefaultConfigStore) Alias(from, to string) {
 // one didn't previously exist.
 func (s *DefaultConfigStore) SetLevel(level ConfigLevel, key string, value interface{}) {
 	s.setIfNotExists(level, key, value)
+	s.writeIfLog(key, value)
 }
 
 // Find searches for the given key, returning the discovered value and a
 // boolean indicating whether or not the key was found
 func (s *DefaultConfigStore) Find(key string) (interface{}, bool) {
-	return s.find(key)
+	val, bl := s.find(key)
+	s.writeIfLog(key, val)
+	return val, bl
 }
 
 // Merge merges the provided config map into the ConfigLevel l, allocating
@@ -108,6 +123,12 @@ func (s *DefaultConfigStore) setIfNotExists(l ConfigLevel, key string, value int
 		heap.Push(s.usedLevels, l)
 	}
 	setNested(s.config[l], strings.Split(key, Delim), value)
+}
+
+func (s *DefaultConfigStore) writeIfLog(a ...interface{}) {
+	if s.log != nil {
+		s.log.Write(a)
+	}
 }
 
 // setNested inserts the provided value into the nested keyspace as defined by
@@ -161,27 +182,6 @@ func (s *DefaultConfigStore) Clear() {
 func (s *DefaultConfigStore) Debug() string {
 	b, _ := json.MarshalIndent(s.config, "", "  ")
 	return string(b)
-}
-
-// SetLogger is not implemented for a DefaultConfigStore and is present
-// only to satisfy the ConfigStore interface.
-func (s *DefaultConfigStore) SetLogger(lg LoggingInterface) {
-}
-
-// GetLogger is not implemented for a DefaultConfigStore and is present
-// only to satisfy the ConfigStore interface.
-func (s *DefaultConfigStore) GetLogger() LoggingInterface {
-	return nil
-}
-
-// SetPrefix is not implemented for a DefaultConfigStore and is present
-// only to satisfy the ConfigStore interface.
-func (s *DefaultConfigStore) SetPrefix(str string) {
-}
-
-// SetSuffix is not implemented for a DefaultConfigStore and is present
-// only to satisfy the ConfigStore interface.
-func (s *DefaultConfigStore) SetSuffix(str string) {
 }
 
 // SafeConfigStore implements the ConfigStore interface and provides a store
@@ -266,40 +266,27 @@ func (s *SafeConfigStore) Size() int {
 	return s.c.Size()
 }
 
-// SetLogger is not implemented for a DefaultConfigStore and is present
-// only to satisfy the ConfigStore interface.
-func (s *SafeConfigStore) SetLogger(lg LoggingInterface) {
-}
-
-// GetLogger is not implemented for a DefaultConfigStore and is present
-// only to satisfy the ConfigStore interface.
-func (s *SafeConfigStore) GetLogger() LoggingInterface {
-	return nil
-}
-
-// SetPrefix is not implemented for a DefaultConfigStore and is present
-// only to satisfy the ConfigStore interface.
-func (s *SafeConfigStore) SetPrefix(str string) {
-}
-
-// SetSuffix is not implemented for a DefaultConfigStore and is present
-// only to satisfy the ConfigStore interface.
-func (s *SafeConfigStore) SetSuffix(str string) {
-}
-
 // LogableConfigStore implements the ConfigStore interface and provides a store
 // that is safe to read and write from multiple goroutines.
 type LogableConfigStore struct {
-    c  *DefaultConfigStore
-    logger *DefaultLogger
+	c  *DefaultConfigStore
 }
 
-// NewLogableConfigStore returns a new LogableConfigStore.
+// NewLogableConfigStore takes a LoggingInterface and returns a new ConfigStore
+// with said interface as the logging mechanism used for read and writes.
+func NewLogableConfigStoreWith(l LoggingInterface) ConfigStore {
+	return &LogableConfigStore{
+		c: newLogableConfigStoreWith(l),
+	}
+}
+
+// NewLogableConfigStore returns a ConfigStore with a default logging mechanism
+// set to write to os.Stdout.
 func NewLogableConfigStore() ConfigStore {
-    return &LogableConfigStore{
-        c: NewDefaultConfigStore(),
-        logger: NewDefaultLogger(),
-    }
+	l := log.New(os.Stdout, "", 0)
+	return &LogableConfigStore{
+		c: newLogableConfigStoreWith(l),
+	}
 }
 
 // RegisterResolver registers a custom config resolver for the specified
@@ -308,77 +295,49 @@ func NewLogableConfigStore() ConfigStore {
 // Additionally, if the provided level is not already in the current collection
 // of active config levels, it will be added automatically
 func (l *LogableConfigStore) RegisterResolver(level ConfigLevel, r Resolver) {
-    l.c.RegisterResolver(level, r)
+	l.c.RegisterResolver(level, r)
 }
 
 // SetLevel is a generic key/value setter method. It sets the provided k/v at
 // the specified level inside the map, conditionally creating a new ConfigMap if
 // one didn't previously exist.
 func (l *LogableConfigStore) SetLevel(level ConfigLevel, key string, value interface{}) {
-    l.c.SetLevel(level, key, value)
-    l.logger.Write(key, value)
+	l.c.SetLevel(level, key, value)
 }
 
 // Merge merges the provided config map into the ConfigLevel l, allocating
 // space for ConfigLevel l if the level hasn't already been allocated.
 func (l *LogableConfigStore) Merge(cl ConfigLevel, data ConfigMap) {
-    l.c.Merge(cl, data)
+	l.c.Merge(cl, data)
 }
 
 // Alias registers an alias for a given key. This allows consumers to access
 // the same config via a different key, increasing the backwards
 // compatibility of an application.
 func (l *LogableConfigStore) Alias(from, to string) {
-    l.c.Alias(from, to)
+	l.c.Alias(from, to)
 }
 
 // Find searches for the given key, returning the discovered value and a
 // boolean indicating whether or not the key was found
 func (l *LogableConfigStore) Find(key string) (interface{}, bool) {
 	a, b := l.c.Find(key)
-	if b {
-		l.logger.Write(a)
-	}
-    return a, b
+	return a, b
 }
 
 // Clear removes all data from the ConfigLevelMap and resets the heap of config
 // levels.
 func (l *LogableConfigStore) Clear() {
-    l.c.Clear()
+	l.c.Clear()
 }
 
 // Debug returns the current venom ConfigLevelMap as a pretty-printed JSON
 // string.
 func (l *LogableConfigStore) Debug() string {
-    return l.c.Debug()
+	return l.c.Debug()
 }
 
 // Size returns the number of config levels stored in this ConfigStore.
 func (l *LogableConfigStore) Size() int {
-    return l.c.Size()
-}
-
-// SetLogger takes a LoggingInterface and sets the DefaultLogger's log field
-// as such.
-func (l *LogableConfigStore) SetLogger(lg LoggingInterface) {
-	l.logger.SetLogger(lg)
-}
-
-// GetLogger returns a LoggingInterface which is the log field of the
-// DefaultLogger.
-func (l *LogableConfigStore) GetLogger() LoggingInterface {
-	return l.logger.log
-}
-
-// SetPrefix takes a string and sets it as the DefaultLogger's prefix field.
-// This field is used as the Prefix in the formatted log line.
-func (l *LogableConfigStore) SetPrefix(s string) {
-	l.logger.SetPrefix(s)
-}
-
-// SetSuffix takes a string and sets it as the DefaultLogger's suffix field.
-// This field is used as the Suffix in the formatted log line.
-func (l *LogableConfigStore) SetSuffix(s string) {
-	l.logger.SetSuffix(s)
+	return l.c.Size()
 }

--- a/store.go
+++ b/store.go
@@ -247,7 +247,7 @@ func (s *SafeConfigStore) Size() int {
 // a field for reference to a logging mechanism to log on reads/writes
 type LoggableConfigStore struct {
 	c   ConfigStore
-	log DefaultLogger
+	log Logging
 }
 
 // NewLoggableConfigStore takes a Logging and returns a new ConfigStore
@@ -255,7 +255,7 @@ type LoggableConfigStore struct {
 func NewLoggableConfigStoreWith(l Logging) ConfigStore {
 	return &LoggableConfigStore{
 		c: NewDefaultConfigStore(),
-		log: NewLogger(l),
+		log: l,
 	}
 }
 
@@ -280,7 +280,7 @@ func (l *LoggableConfigStore) RegisterResolver(level ConfigLevel, r Resolver) {
 // one didn't previously exist.
 func (l *LoggableConfigStore) SetLevel(level ConfigLevel, key string, value interface{}) {
 	l.c.SetLevel(level, key, value)
-	l.log.Write("SET", level, key, value)
+	l.log.Print(formatLogLine("SET", level, key, value))
 }
 
 // Merge merges the provided config map into the ConfigLevel l, allocating
@@ -300,7 +300,7 @@ func (l *LoggableConfigStore) Alias(from, to string) {
 // boolean indicating whether or not the key was found
 func (l *LoggableConfigStore) Find(key string) (interface{}, bool) {
 	a, b := l.c.Find(key)
-	l.log.Write("GET", a, b)
+	l.log.Print(formatLogLine("GET", a, b))
 	return a, b
 }
 

--- a/store.go
+++ b/store.go
@@ -244,17 +244,17 @@ func (s *SafeConfigStore) Size() int {
 }
 
 // LoggableConfigStore implements the ConfigStore interface and provides a store
-// a field for reference to a logging mechanism to log on reads/writes
+// a field for reference to a LogWrapper to log on reads and writes.
 type LoggableConfigStore struct {
 	c   ConfigStore
-	log Logging
+	log LogWrapper
 }
 
-// NewLoggableConfigStore takes a Logging and returns a new ConfigStore
+// NewLoggableConfigStore takes a LogWrapper and returns a new ConfigStore
 // with said interface as the logging mechanism used for read and writes.
-func NewLoggableConfigStoreWith(l Logging) ConfigStore {
+func NewLoggableConfigStoreWith(l LogWrapper) ConfigStore {
 	return &LoggableConfigStore{
-		c: NewDefaultConfigStore(),
+		c:   NewDefaultConfigStore(),
 		log: l,
 	}
 }
@@ -262,7 +262,7 @@ func NewLoggableConfigStoreWith(l Logging) ConfigStore {
 // NewLoggableConfigStore returns a ConfigStore with a default logging mechanism
 // set to write to os.Stdout.
 func NewLoggableConfigStore() ConfigStore {
-	l := log.New(os.Stdout, "", 0)
+	l := NewEntry(log.New(os.Stdout, "", 0))
 	return NewLoggableConfigStoreWith(l)
 }
 
@@ -280,7 +280,7 @@ func (l *LoggableConfigStore) RegisterResolver(level ConfigLevel, r Resolver) {
 // one didn't previously exist.
 func (l *LoggableConfigStore) SetLevel(level ConfigLevel, key string, value interface{}) {
 	l.c.SetLevel(level, key, value)
-	l.log.Print(formatLogLine("SET", level, key, value))
+	l.log.LogWrite(level, key, value)
 }
 
 // Merge merges the provided config map into the ConfigLevel l, allocating
@@ -300,7 +300,7 @@ func (l *LoggableConfigStore) Alias(from, to string) {
 // boolean indicating whether or not the key was found
 func (l *LoggableConfigStore) Find(key string) (interface{}, bool) {
 	a, b := l.c.Find(key)
-	l.log.Print(formatLogLine("GET", a, b))
+	l.log.LogRead(key, a, b)
 	return a, b
 }
 

--- a/store.go
+++ b/store.go
@@ -243,16 +243,16 @@ func (s *SafeConfigStore) Size() int {
 	return s.c.Size()
 }
 
-// LoggableConfigStore implements the ConfigStore interface and provides a store
-// a field for reference to a LogWrapper to log on reads and writes.
+// LoggableConfigStore implements the ConfigStore interface and provides a log
+// field for reference to a Logger which will log on reads and writes.
 type LoggableConfigStore struct {
 	c   ConfigStore
-	log LogWrapper
+	log Logger
 }
 
-// NewLoggableConfigStore takes a LogWrapper and returns a new ConfigStore
+// NewLoggableConfigStore takes a Logger and returns a new ConfigStore
 // with said interface as the logging mechanism used for read and writes.
-func NewLoggableConfigStoreWith(l LogWrapper) ConfigStore {
+func NewLoggableConfigStoreWith(l Logger) ConfigStore {
 	return &LoggableConfigStore{
 		c:   NewDefaultConfigStore(),
 		log: l,
@@ -262,7 +262,7 @@ func NewLoggableConfigStoreWith(l LogWrapper) ConfigStore {
 // NewLoggableConfigStore returns a ConfigStore with a default logging mechanism
 // set to write to os.Stdout.
 func NewLoggableConfigStore() ConfigStore {
-	l := NewEntry(log.New(os.Stdout, "", 0))
+	l := NewStoreLogger(log.New(os.Stdout, "", 0))
 	return NewLoggableConfigStoreWith(l)
 }
 

--- a/store.go
+++ b/store.go
@@ -263,10 +263,7 @@ func NewLoggableConfigStoreWith(l Logging) ConfigStore {
 // set to write to os.Stdout.
 func NewLoggableConfigStore() ConfigStore {
 	l := log.New(os.Stdout, "", 0)
-	return &LoggableConfigStore{
-		c: NewDefaultConfigStore(),
-		log: NewLogger(l),		
-	}
+	return NewLoggableConfigStoreWith(l)
 }
 
 // RegisterResolver registers a custom config resolver for the specified

--- a/store_test.go
+++ b/store_test.go
@@ -10,6 +10,9 @@ func TestConfigStoreSetAndFind(t *testing.T) {
 	t.Run("SafeConfigStore", func(t *testing.T) {
 		testVenom(t, NewSafeConfigStore())
 	})
+	t.Run("LogableConfigStore", func(t *testing.T) {
+		testVenom(t, NewLogableConfigStore())
+	})
 	t.Run("Venom", func(t *testing.T) {
 		testVenom(t, New())
 	})
@@ -31,6 +34,9 @@ func TestConfigStoreDebug(t *testing.T) {
 	})
 	t.Run("SafeConfigStore", func(t *testing.T) {
 		testDebug(t, NewSafeConfigStore())
+	})
+	t.Run("LogableConfigStore", func(t *testing.T) {
+		testDebug(t, NewLogableConfigStore())
 	})
 	t.Run("Venom", func(t *testing.T) {
 		testDebug(t, New())
@@ -54,6 +60,9 @@ func TestConfigStoreAlias(t *testing.T) {
 	t.Run("SafeConfigStore", func(t *testing.T) {
 		testAlias(t, NewSafeConfigStore())
 	})
+	t.Run("LogableConfigStore", func(t *testing.T) {
+		testAlias(t, NewLogableConfigStore())
+	})
 	t.Run("Venom", func(t *testing.T) {
 		testAlias(t, New())
 	})
@@ -75,6 +84,9 @@ func TestConfigStoreEdgeCases(t *testing.T) {
 	})
 	t.Run("SafeConfigStore", func(t *testing.T) {
 		testEdgeCases(t, NewSafeConfigStore())
+	})
+	t.Run("LogableConfigStore", func(t *testing.T) {
+		testEdgeCases(t, NewLogableConfigStore())
 	})
 	t.Run("Venom", func(t *testing.T) {
 		testEdgeCases(t, New())

--- a/store_test.go
+++ b/store_test.go
@@ -10,8 +10,8 @@ func TestConfigStoreSetAndFind(t *testing.T) {
 	t.Run("SafeConfigStore", func(t *testing.T) {
 		testVenom(t, NewSafeConfigStore())
 	})
-	t.Run("LogableConfigStore", func(t *testing.T) {
-		testVenom(t, NewLogableWith(&TestLogger{}))
+	t.Run("LoggableConfigStore", func(t *testing.T) {
+		testVenom(t, NewLoggableWith(&TestLogger{}))
 	})
 	t.Run("Venom", func(t *testing.T) {
 		testVenom(t, New())
@@ -35,8 +35,8 @@ func TestConfigStoreDebug(t *testing.T) {
 	t.Run("SafeConfigStore", func(t *testing.T) {
 		testDebug(t, NewSafeConfigStore())
 	})
-	t.Run("LogableConfigStore", func(t *testing.T) {
-		testDebug(t, NewLogableConfigStore())
+	t.Run("LoggableConfigStore", func(t *testing.T) {
+		testDebug(t, NewLoggableConfigStore())
 	})
 	t.Run("Venom", func(t *testing.T) {
 		testDebug(t, New())
@@ -60,8 +60,8 @@ func TestConfigStoreAlias(t *testing.T) {
 	t.Run("SafeConfigStore", func(t *testing.T) {
 		testAlias(t, NewSafeConfigStore())
 	})
-	t.Run("LogableConfigStore", func(t *testing.T) {
-		testAlias(t, NewLogableWith(&TestLogger{}))
+	t.Run("LoggableConfigStore", func(t *testing.T) {
+		testAlias(t, NewLoggableWith(&TestLogger{}))
 	})
 	t.Run("Venom", func(t *testing.T) {
 		testAlias(t, New())
@@ -85,8 +85,8 @@ func TestConfigStoreEdgeCases(t *testing.T) {
 	t.Run("SafeConfigStore", func(t *testing.T) {
 		testEdgeCases(t, NewSafeConfigStore())
 	})
-	t.Run("LogableConfigStore", func(t *testing.T) {
-		testEdgeCases(t, NewLogableWith(&TestLogger{}))
+	t.Run("LoggableConfigStore", func(t *testing.T) {
+		testEdgeCases(t, NewLoggableWith(&TestLogger{}))
 	})
 	t.Run("Venom", func(t *testing.T) {
 		testEdgeCases(t, New())

--- a/store_test.go
+++ b/store_test.go
@@ -11,7 +11,7 @@ func TestConfigStoreSetAndFind(t *testing.T) {
 		testVenom(t, NewSafeConfigStore())
 	})
 	t.Run("LoggableConfigStore", func(t *testing.T) {
-		testVenom(t, NewLoggableWith(&TestLogger{}))
+		testVenom(t, NewLoggableWith(&TestLogWrapper{}))
 	})
 	t.Run("Venom", func(t *testing.T) {
 		testVenom(t, New())
@@ -61,7 +61,7 @@ func TestConfigStoreAlias(t *testing.T) {
 		testAlias(t, NewSafeConfigStore())
 	})
 	t.Run("LoggableConfigStore", func(t *testing.T) {
-		testAlias(t, NewLoggableWith(&TestLogger{}))
+		testAlias(t, NewLoggableWith(&TestLogWrapper{}))
 	})
 	t.Run("Venom", func(t *testing.T) {
 		testAlias(t, New())
@@ -86,7 +86,7 @@ func TestConfigStoreEdgeCases(t *testing.T) {
 		testEdgeCases(t, NewSafeConfigStore())
 	})
 	t.Run("LoggableConfigStore", func(t *testing.T) {
-		testEdgeCases(t, NewLoggableWith(&TestLogger{}))
+		testEdgeCases(t, NewLoggableWith(&TestLogWrapper{}))
 	})
 	t.Run("Venom", func(t *testing.T) {
 		testEdgeCases(t, New())

--- a/store_test.go
+++ b/store_test.go
@@ -11,7 +11,7 @@ func TestConfigStoreSetAndFind(t *testing.T) {
 		testVenom(t, NewSafeConfigStore())
 	})
 	t.Run("LoggableConfigStore", func(t *testing.T) {
-		testVenom(t, NewLoggableWith(&TestLogWrapper{}))
+		testVenom(t, NewLoggableWith(&TestLogger{}))
 	})
 	t.Run("Venom", func(t *testing.T) {
 		testVenom(t, New())
@@ -61,7 +61,7 @@ func TestConfigStoreAlias(t *testing.T) {
 		testAlias(t, NewSafeConfigStore())
 	})
 	t.Run("LoggableConfigStore", func(t *testing.T) {
-		testAlias(t, NewLoggableWith(&TestLogWrapper{}))
+		testAlias(t, NewLoggableWith(&TestLogger{}))
 	})
 	t.Run("Venom", func(t *testing.T) {
 		testAlias(t, New())
@@ -86,7 +86,7 @@ func TestConfigStoreEdgeCases(t *testing.T) {
 		testEdgeCases(t, NewSafeConfigStore())
 	})
 	t.Run("LoggableConfigStore", func(t *testing.T) {
-		testEdgeCases(t, NewLoggableWith(&TestLogWrapper{}))
+		testEdgeCases(t, NewLoggableWith(&TestLogger{}))
 	})
 	t.Run("Venom", func(t *testing.T) {
 		testEdgeCases(t, New())

--- a/store_test.go
+++ b/store_test.go
@@ -11,9 +11,7 @@ func TestConfigStoreSetAndFind(t *testing.T) {
 		testVenom(t, NewSafeConfigStore())
 	})
 	t.Run("LogableConfigStore", func(t *testing.T) {
-		lg := NewLogableConfigStore()
-		lg.SetLogger(&TestLogger{})
-		testVenom(t, lg)
+		testVenom(t, NewLogableWith(&TestLogger{}))
 	})
 	t.Run("Venom", func(t *testing.T) {
 		testVenom(t, New())
@@ -63,9 +61,7 @@ func TestConfigStoreAlias(t *testing.T) {
 		testAlias(t, NewSafeConfigStore())
 	})
 	t.Run("LogableConfigStore", func(t *testing.T) {
-		lg := NewLogableConfigStore()
-		lg.SetLogger(&TestLogger{})		
-		testAlias(t, lg)
+		testAlias(t, NewLogableWith(&TestLogger{}))
 	})
 	t.Run("Venom", func(t *testing.T) {
 		testAlias(t, New())
@@ -90,9 +86,7 @@ func TestConfigStoreEdgeCases(t *testing.T) {
 		testEdgeCases(t, NewSafeConfigStore())
 	})
 	t.Run("LogableConfigStore", func(t *testing.T) {
-		lg := NewLogableConfigStore()
-		lg.SetLogger(&TestLogger{})		
-		testEdgeCases(t, lg)
+		testEdgeCases(t, NewLogableWith(&TestLogger{}))
 	})
 	t.Run("Venom", func(t *testing.T) {
 		testEdgeCases(t, New())

--- a/store_test.go
+++ b/store_test.go
@@ -11,7 +11,9 @@ func TestConfigStoreSetAndFind(t *testing.T) {
 		testVenom(t, NewSafeConfigStore())
 	})
 	t.Run("LogableConfigStore", func(t *testing.T) {
-		testVenom(t, NewLogableConfigStore())
+		lg := NewLogableConfigStore()
+		lg.SetLogger(&TestLogger{})
+		testVenom(t, lg)
 	})
 	t.Run("Venom", func(t *testing.T) {
 		testVenom(t, New())
@@ -61,7 +63,9 @@ func TestConfigStoreAlias(t *testing.T) {
 		testAlias(t, NewSafeConfigStore())
 	})
 	t.Run("LogableConfigStore", func(t *testing.T) {
-		testAlias(t, NewLogableConfigStore())
+		lg := NewLogableConfigStore()
+		lg.SetLogger(&TestLogger{})		
+		testAlias(t, lg)
 	})
 	t.Run("Venom", func(t *testing.T) {
 		testAlias(t, New())
@@ -86,7 +90,9 @@ func TestConfigStoreEdgeCases(t *testing.T) {
 		testEdgeCases(t, NewSafeConfigStore())
 	})
 	t.Run("LogableConfigStore", func(t *testing.T) {
-		testEdgeCases(t, NewLogableConfigStore())
+		lg := NewLogableConfigStore()
+		lg.SetLogger(&TestLogger{})		
+		testEdgeCases(t, lg)
 	})
 	t.Run("Venom", func(t *testing.T) {
 		testEdgeCases(t, New())

--- a/venom.go
+++ b/venom.go
@@ -65,9 +65,9 @@ func NewSafe() *Venom {
 	return NewWithStore(NewSafeConfigStore())
 }
 
-// NewLoggable takes a LogWrapper and returns a newly initialized Venom
+// NewLoggable takes a Logger and returns a newly initialized Venom
 // instance that will log to a Logger interface upon reads and writes.
-func NewLoggableWith(l LogWrapper) *Venom {
+func NewLoggableWith(l Logger) *Venom {
 	lcs := NewLoggableConfigStoreWith(l)
 	return NewWithStore(lcs)
 }

--- a/venom.go
+++ b/venom.go
@@ -65,9 +65,9 @@ func NewSafe() *Venom {
 	return NewWithStore(NewSafeConfigStore())
 }
 
-// NewLoggable takes a Logging and returns a newly initialized Venom
-// instance that will log to said interface upon reads and writes.
-func NewLoggableWith(l Logging) *Venom {
+// NewLoggable takes a LogWrapper and returns a newly initialized Venom
+// instance that will log to a Logger interface upon reads and writes.
+func NewLoggableWith(l LogWrapper) *Venom {
 	lcs := NewLoggableConfigStoreWith(l)
 	return NewWithStore(lcs)
 }

--- a/venom.go
+++ b/venom.go
@@ -167,3 +167,27 @@ func (v *Venom) Debug() string {
 func (v *Venom) Size() int {
 	return v.Store.Size()
 }
+
+// SetLogger takes a LoggingInterface which can be any type which implements
+// the function Print(...interface{}) and sets that logging interface as the
+// log used by the underlying ConfigStore
+func (v *Venom) SetLogger(l LoggingInterface) {
+	v.Store.SetLogger(l)
+}
+
+// GetLogger returns the LoggingInterface from the underlying ConfigStore
+func (v *Venom) GetLogger() LoggingInterface {
+	return v.Store.GetLogger()
+}
+
+// SetPrefix sets the leading value of the structured log line when using a
+// LogableConfigStore as the underlying ConfigStore
+func (v *Venom)	SetPrefix(s string) {
+	v.Store.SetPrefix(s)
+}
+
+// SetSuffix sets the trailing value of the structured log line when using a
+// LogableConfigStore as the underlying ConfigStore
+func (v *Venom)	SetSuffix(s string) {
+	v.Store.SetSuffix(s)
+}

--- a/venom.go
+++ b/venom.go
@@ -67,8 +67,14 @@ func NewSafe() *Venom {
 	return NewWithStore(NewSafeConfigStore())
 }
 
-// NewLogable returns a newly initialized Venom instance that will log to an
-// interface (default is stdout) when reads and writes are done.
+// NewLogable takes a LoggingInterface and returns a newly initialized Venom
+// instance that will log to said interface upon reads and writes.
+func NewLogableWith(l LoggingInterface) *Venom {
+	lcs := NewLogableConfigStoreWith(l)
+	return NewWithStore(lcs)
+}
+
+// NewLogable returns a Venom instance with a default log set to standard out.
 func NewLogable() *Venom {
 	return NewWithStore(NewLogableConfigStore())
 }
@@ -166,28 +172,4 @@ func (v *Venom) Debug() string {
 // ConfigStore.
 func (v *Venom) Size() int {
 	return v.Store.Size()
-}
-
-// SetLogger takes a LoggingInterface which can be any type which implements
-// the function Print(...interface{}) and sets that logging interface as the
-// log used by the underlying ConfigStore
-func (v *Venom) SetLogger(l LoggingInterface) {
-	v.Store.SetLogger(l)
-}
-
-// GetLogger returns the LoggingInterface from the underlying ConfigStore
-func (v *Venom) GetLogger() LoggingInterface {
-	return v.Store.GetLogger()
-}
-
-// SetPrefix sets the leading value of the structured log line when using a
-// LogableConfigStore as the underlying ConfigStore
-func (v *Venom)	SetPrefix(s string) {
-	v.Store.SetPrefix(s)
-}
-
-// SetSuffix sets the trailing value of the structured log line when using a
-// LogableConfigStore as the underlying ConfigStore
-func (v *Venom)	SetSuffix(s string) {
-	v.Store.SetSuffix(s)
 }

--- a/venom.go
+++ b/venom.go
@@ -67,6 +67,12 @@ func NewSafe() *Venom {
 	return NewWithStore(NewSafeConfigStore())
 }
 
+// NewLogable returns a newly initialized Venom instance that will log to an
+// interface (default is stdout) when reads and writes are done.
+func NewLogable() *Venom {
+	return NewWithStore(NewLogableConfigStore())
+}
+
 // NewWithStore returns a newly initialized Venom instance that wraps the
 // provided ConfigStore.
 func NewWithStore(s ConfigStore) *Venom {

--- a/venom.go
+++ b/venom.go
@@ -45,8 +45,6 @@ type ConfigLevelMap map[ConfigLevel]ConfigMap
 // Venom is the configuration registry responsible for storing and managing
 // arbitrary configuration keys and values.
 type Venom struct {
-	// Store is the storage mechanism used by this venom instance to manage
-	// it's underlying configuration storage.
 	Store ConfigStore
 }
 
@@ -67,16 +65,16 @@ func NewSafe() *Venom {
 	return NewWithStore(NewSafeConfigStore())
 }
 
-// NewLogable takes a LoggingInterface and returns a newly initialized Venom
+// NewLoggable takes a Logging and returns a newly initialized Venom
 // instance that will log to said interface upon reads and writes.
-func NewLogableWith(l LoggingInterface) *Venom {
-	lcs := NewLogableConfigStoreWith(l)
+func NewLoggableWith(l Logging) *Venom {
+	lcs := NewLoggableConfigStoreWith(l)
 	return NewWithStore(lcs)
 }
 
-// NewLogable returns a Venom instance with a default log set to standard out.
-func NewLogable() *Venom {
-	return NewWithStore(NewLogableConfigStore())
+// NewLoggable returns a Venom instance with a default log set to standard out.
+func NewLoggable() *Venom {
+	return NewWithStore(NewLoggableConfigStore())
 }
 
 // NewWithStore returns a newly initialized Venom instance that wraps the


### PR DESCRIPTION
### What I Did:
Added the functionality to create a new configuration store which logs upon writes and reads. One can opt for the default log which is the `io.Writer`,`os.Stdout` in a `pkg/log/#Logger` or one can construct their own logging mechanism and initialize the configuration store with such.

### How I Did it:
Introduce LoggingInterface and Wrapper Struct:
```go
// logger.go
type LoggingInterface interface {
	Print(...interface{})
}

type DefaultLogger struct {
	log    LoggingInterface
	suffix string
}
```
Added 'nil-able' Pointer Field on DefaultConfigStore:
```go
// store.go
type DefaultConfigStore struct {
	config ConfigLevelMap
	usedLevels *ConfigLevelHeap
	resolvers map[ConfigLevel]Resolver
	aliases map[string]string
	log *DefaultLogger
}
```
Added Unexported DefaultConfigStore Constructors:
```go
// store.go
func newLogableConfigStoreWith(l LoggingInterface) *DefaultConfigStore
```
Added Exported Venom Constructors:
```go
// venom.go
func NewLogable() *Venom
func NewLogableWith(l LoggingInterface) *Venom
```

### How I Know it Works
Added unit tests and maintained existing tests
```
venom [I9-logging-config] :> make test
go test -coverprofile=coverage.out
flag provided but not defined: -verbose
Usage of test:
PASS
coverage: 96.8% of statements
ok  	github.com/moogar0880/venom	0.047s
```
### Relates To: [Issue #9](https://github.com/moogar0880/venom/issues/9)